### PR TITLE
Fix flaky test testCollectionToArray2

### DIFF
--- a/src/test/java/org/apache/commons/collections4/set/TransformedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/TransformedSetTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.LinkedHashSet;
 
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
@@ -57,7 +58,7 @@ public class TransformedSetTest<E> extends AbstractSetTest<E> {
     @Override
     @SuppressWarnings("unchecked")
     public Set<E> makeFullCollection() {
-        final Set<E> list = new HashSet<>(Arrays.asList(getFullElements()));
+        final Set<E> list = new LinkedHashSet<>(Arrays.asList(getFullElements()));
         return TransformedSet.transformingSet(list,
                 (Transformer<E, E>) TransformedCollectionTest.NOOP_TRANSFORMER);
     }


### PR DESCRIPTION
### Description

The test org.apache.commons.collections4.set.TransformedSetTest.testCollectionToArray2 was found to be flaky when using [Nondex](https://github.com/TestingResearchIllinois/NonDex) tool. 

Command to reproduce:
`mvn -pl . test edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest= org.apache.commons.collections4.set.TransformedSetTest#testCollectionToArray2 -Drat.skip
`

Test failure due to flakiness:
`[ERROR] org.apache.commons.collections4.set.TransformedSetTest.testCollectionToArray2`
`[ERROR]   Run 1: TransformedSetTest>AbstractCollectionTest.testCollectionToArray2:1098 toArrays should be equal` `expected:<[Eight, Seven, Three, 10, 4, 14, 11, null, 6.0, Nine, , 15, 16, 2, One, 5.0, Thirteen, 12]> but was:<[, One, 10, 4, 2, null, Thirteen, 14, 16, Nine, Seven, 11, Three, 12, 6.0, 5.0, 15, Eight]>`
`[ERROR]   Run 2: TransformedSetTest>AbstractCollectionTest.testCollectionToArray2:1098 toArrays should be equal` `expected:<[14, One, Nine, 11, 12, 15, Thirteen, 6.0, 16, Three, Seven, 4, 2, null, , 10, 5.0, Eight]> but was:<[Eight, 16, 15, 2, Three, Thirteen, 12, 11, 4, Seven, 5.0, null, One, 6.0, Nine, 10, , 14]>
`

### Investigation
The testCollectionToArray2 method tests whether toArray() method returns equal arrays. The expected and outcome arrays are created using the getCollection() method which returns a Collection defined as a HashSet in the TransformedSetTest::makeFullCollection() method. 
A [HashSet](https://docs.oracle.com/javase/8/docs/api/java/util/HashSet.html) makes no guarantee of the iteration order of the set, causing the following assertion to fail:
```
array = getCollection().toArray(new Object[0]);
a = getCollection().toArray();
assertEquals("toArrays should be equal", Arrays.asList(array), Arrays.asList(a));
```

### Proposed Fix
[LinkedHashSet](https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashSet.html?is-external=true) may be used instead of HashSet in TransformedSetTest::makeFullCollection() to make the set iteration deterministic as the iteration order would be predictable.
